### PR TITLE
chore: update SDK to 2.0.8-rc1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "OneStepSDK",
-            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.7-rc4/OneStepSDK.xcframework.zip",
-            checksum: "3bdf19679eaba8d2a10e006d01494a5da323a70a59cd48deff230e794c79b930"
+            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.8-rc1/OneStepSDK.xcframework.zip",
+            checksum: "9e2cc63d959d80a53483fd061727cd5664ff264ece49e419c89dbba1e245ae87"
         ),
     ]
 )


### PR DESCRIPTION
Release 2.0.8-rc1. Checksum: `9e2cc63d959d80a53483fd061727cd5664ff264ece49e419c89dbba1e245ae87`. Assets in https://github.com/OneStepRND/onestep-sdk-ios/releases/tag/2.0.8-rc1