### PR TITLE
chore: update SDK to 2.0.8-rc3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "OneStepSDK",
-            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.8-rc2/OneStepSDK.xcframework.zip",
-            checksum: "82489ca5fbefcf4d6fa25ac0cceb811c50987999e1d9cbbfe14882bf39813cb4"
+            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.8-rc3/OneStepSDK.xcframework.zip",
+            checksum: "7fa9109da22cbdcc97c7b597e955a12ec3f502fac1fc746733b574674b049921"
         ),
     ]
 )


### PR DESCRIPTION
Release 2.0.8-rc3. Checksum: `7fa9109da22cbdcc97c7b597e955a12ec3f502fac1fc746733b574674b049921`. Assets in https://github.com/OneStepRND/onestep-sdk-ios/releases/tag/2.0.8-rc3