### PR TITLE
chore: promote SDK 2.0.8-rc4 → 2.0.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "OneStepSDK",
-            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.8-rc4/OneStepSDK.xcframework.zip",
+            url: "https://github.com/OneStepRND/onestep-sdk-ios/releases/download/2.0.8/OneStepSDK.xcframework.zip",
             checksum: "2eddf9ed21bed453cf841e51ca0d17f3ba7ab36fa54e95351358ecaf717b24b6"
         ),
     ]


### PR DESCRIPTION
Promote 2.0.8-rc4 to 2.0.8 final. Byte-identical binary (checksum 2eddf9ed21bed453cf841e51ca0d17f3ba7ab36fa54e95351358ecaf717b24b6); only the Package.swift download URL is repointed rc4→2.0.8. The 2.0.8 release is created with the same asset bytes the rc shipped.